### PR TITLE
Delete Unused Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,0 @@
-ASpaceGems.setup if defined? ASpaceGems
-
-source 'http://rubygems.org'
-
-# gem 'saxon-xslt', '~> 0.8', '>= 0.8.2.1'
-gem 'saxon-rb', '~> 0.8.3'
-#gem 'saxon-xslt', '>= 0'


### PR DESCRIPTION
This removes the gemfile because saxon-rb is now in base aspace (3.5.1+). If using a version before saxon-rb was in this will not work